### PR TITLE
Add sq() and tri() texture generators

### DIFF
--- a/src/glsl-source.js
+++ b/src/glsl-source.js
@@ -69,6 +69,9 @@ GlslSource.prototype.compile = function (transforms) {
 
   var frag = `
   precision ${this.defaultOutput.precision} float;
+
+  #define PI 3.1415926538
+
   ${Object.values(shaderInfo.uniforms).map((uniform) => {
     let type = uniform.type
     switch (uniform.type) {

--- a/src/glsl/glsl-functions.js
+++ b/src/glsl/glsl-functions.js
@@ -162,6 +162,44 @@ module.exports = () => [
    float b = sin((st.x+offset/frequency+time*sync)*frequency)*0.5  + 0.5;
    return vec4(r, g, b, 1.0);`
 },
+  {
+  name: 'tri',
+  type: 'src',
+  inputs: [
+    {
+      type: 'float',
+      name: 'frequency',
+      default: 60,
+    },
+    {
+      type: 'float',
+      name: 'sync',
+      default: 0.1,
+    },
+  ],
+  glsl: `   vec2 st = _st;
+ float c = (2. / PI) * asin(sin(PI * (st.x + time * sync) * frequency / PI)) * 0.5 + 0.5;
+ return vec4(c, c, c, 1.0);`,
+},
+{
+  name: 'sq',
+  type: 'src',
+  inputs: [
+    {
+      type: 'float',
+      name: 'frequency',
+      default: 60,
+    },
+    {
+      type: 'float',
+      name: 'sync',
+      default: 0.1,
+    },
+  ],
+  glsl: `   vec2 st = _st;
+ float c = floor(sin((st.x + time * sync) * frequency) * 0.5 + 1.);
+ return vec4(c, c, c, 1.0);`,
+},
 {
   name: 'shape',
   type: 'src',


### PR DESCRIPTION
This PR adds square `sq()` waves and triangle `tri()` waves with the same period as `osc()`'s sine wave. This allows for interesting combinations of wave textures, especially when used with `modulate` methods or in feedback loops.

Demo: https://hydra.ojack.xyz/?sketch_id=G6HAU7Y4hIlCIgOa

Note that these generators take two arguments, unlike osc() which allows for a color offset. I don't think a color offset makes sense for a square wave, but I could see an argument for having it in triangle.