### PR TITLE
apply synth speed to video playbackRate

### DIFF
--- a/hydra-synth.js
+++ b/hydra-synth.js
@@ -377,7 +377,7 @@ class HydraRenderer {
   }
 
   createSource (i) {
-    let s = new Source({regl: this.regl, pb: this.pb, width: this.width, height: this.height, label: `s${i}`})
+    let s = new Source({regl: this.regl, pb: this.pb, width: this.width, height: this.height, label: `s${i}`, synth: this.synth})
     this.synth['s' + this.s.length] = s
     this.s.push(s)
     return s

--- a/src/hydra-source.js
+++ b/src/hydra-source.js
@@ -2,7 +2,7 @@ const Webcam = require('./lib/webcam.js')
 const Screen = require('./lib/screenmedia.js')
 
 class HydraSource {
-  constructor ({ regl, width, height, pb, label = ""}) {
+  constructor ({ regl, width, height, pb, label = "", synth }) {
     this.label = label
     this.regl = regl
     this.src = null
@@ -14,6 +14,7 @@ class HydraSource {
       shape: [ 1, 1 ]
     })
     this.pb = pb
+    this.synth = synth
   }
 
   init (opts, params) {
@@ -47,6 +48,7 @@ class HydraSource {
       vid.play()
       this.tex = this.regl.texture({ data: this.src, ...params})
       this.dynamic = true
+      this.videoElement = vid;
     })
     vid.src = url
   }
@@ -121,6 +123,12 @@ class HydraSource {
 
       if (this.src.width && this.src.width !== this.tex.width) {
         this.tex.resize(this.src.width, this.src.height)
+      }
+
+      if (this.videoElement !== undefined) {
+        if (this.videoElement.playbackRate !== this.synth.speed) {
+          this.videoElement.playbackRate = this.synth.speed
+        }
       }
 
       this.tex.subimage(this.src)


### PR DESCRIPTION
Applies synth speed (global var or `synth.speed`) to the video media element's `playbackRate`. This can "break" existing sketches - but I feel it's more intuitive to match these values. Let me know what you think.

Also package json's version is not updated / dist files are not updated so please compile them before merging the PR.