### PR TITLE
fix: Replace use of eval with Function constructor on sandbox

### DIFF
--- a/src/lib/sandbox.js
+++ b/src/lib/sandbox.js
@@ -20,11 +20,12 @@ export default (parent) => {
     eval: (code) => sandbox.eval(code)
   }
 
-  function createSandbox (initial) {
-    eval(initial)
+  function createSandbox(initial) {
+    Function(initial)();
+
     // optional params
-    var localEval = function (code)  {
-      eval(code)
+    var localEval = function (code) {
+      Function(code)();
     }
 
     // API/data for end-user


### PR DESCRIPTION
This fixes minification issues on Rollup/esbuild (and Vite).

I'm not 100% sure I'm not breaking something here, but AFAIK it works the same. @ojack do you think this would work?