### PR TITLE
Make ES module compatible with atom-hydra

### DIFF
--- a/src/eval-sandbox.js
+++ b/src/eval-sandbox.js
@@ -1,3 +1,4 @@
+// @flow
 // handles code evaluation and attaching relevant objects to global and evaluation contexts
 
 import Sandbox from './lib/sandbox.js'

--- a/src/format-arguments.js
+++ b/src/format-arguments.js
@@ -1,3 +1,4 @@
+// @flow
 import arrayUtils from './lib/array-utils.js'
 
 // [WIP] how to treat different dimensions (?)

--- a/src/generate-glsl.js
+++ b/src/generate-glsl.js
@@ -1,3 +1,4 @@
+// @flow
 import formatArguments from './format-arguments.js'
 
 // Add extra functionality to Array.prototype for generating sequences in time

--- a/src/generator-factory.js
+++ b/src/generator-factory.js
@@ -1,3 +1,4 @@
+// @flow
 import GlslSource from './glsl-source.js'
 import glslFunctions from './glsl/glsl-functions.js'
 

--- a/src/glsl-source.js
+++ b/src/glsl-source.js
@@ -1,3 +1,4 @@
+// @flow
 import generateGlsl from './generate-glsl.js'
 // const formatArguments = require('./glsl-utils.js').formatArguments
 

--- a/src/glsl/glsl-functions.js
+++ b/src/glsl/glsl-functions.js
@@ -1,3 +1,4 @@
+// @flow
 /*
 Format for adding functions to hydra. For each entry in this file, hydra automatically generates a glsl function and javascript function with the same name. You can also ass functions dynamically using setFunction(object).
 

--- a/src/glsl/renderpass-functions.js
+++ b/src/glsl/renderpass-functions.js
@@ -1,3 +1,4 @@
+// @flow
 // to add: ripple: https://www.shadertoy.com/view/4djGzz
 // mask
 // convolution

--- a/src/glsl/utility-functions.js
+++ b/src/glsl/utility-functions.js
@@ -1,3 +1,4 @@
+// @flow
 // functions that are only used within other functions
 
 export default {

--- a/src/hydra-source.js
+++ b/src/hydra-source.js
@@ -1,3 +1,5 @@
+// @flow
+
 import Webcam from './lib/webcam.js'
 import Screen from './lib/screenmedia.js'
 

--- a/src/hydra-synth.js
+++ b/src/hydra-synth.js
@@ -1,3 +1,4 @@
+// @flow
 
 import Output from './output.js'
 import loop from 'raf-loop'

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+// @flow
+
 import Synth from './hydra-synth.js'
 //import ShaderGenerator = require('./shader-generator.js')
 // alert('hi')

--- a/src/lib/array-utils.js
+++ b/src/lib/array-utils.js
@@ -1,3 +1,4 @@
+// @flow
 // WIP utils for working with arrays
 // Possibly should be integrated with lfo extension, etc.
 // to do: transform time rather than array values, similar to working with coordinates in hydra

--- a/src/lib/audio.js
+++ b/src/lib/audio.js
@@ -1,3 +1,4 @@
+// @flow
 import Meyda from 'meyda'
 
 class Audio {

--- a/src/lib/easing-functions.js
+++ b/src/lib/easing-functions.js
@@ -1,3 +1,4 @@
+// @flow
 // from https://gist.github.com/gre/1650294
 
 export default {

--- a/src/lib/mouse-event.js
+++ b/src/lib/mouse-event.js
@@ -1,3 +1,4 @@
+// @flow
 // https://github.com/mikolalysenko/mouse-event
 
 const mouse = {}

--- a/src/lib/mouse.js
+++ b/src/lib/mouse.js
@@ -1,3 +1,4 @@
+// @flow
 // based on https://github.com/mikolalysenko/mouse-change
 
 export default mouseListen

--- a/src/lib/sandbox.js
+++ b/src/lib/sandbox.js
@@ -1,3 +1,4 @@
+// @flow
 // attempt custom evaluation sandbox for hydra functions
 // for now, just avoids polluting the global namespace
 // should probably be replaced with an abstract syntax tree

--- a/src/lib/screenmedia.js
+++ b/src/lib/screenmedia.js
@@ -1,3 +1,4 @@
+// @flow
 
 export default function (options) {
   return new Promise(function(resolve, reject) {

--- a/src/lib/video-recorder.js
+++ b/src/lib/video-recorder.js
@@ -1,3 +1,4 @@
+// @flow
 class VideoRecorder {
   constructor(stream) {
     this.mediaSource = new MediaSource()

--- a/src/lib/webcam.js
+++ b/src/lib/webcam.js
@@ -1,3 +1,4 @@
+// @flow
 //const enumerateDevices = require('enumerate-devices')
 
 export default function (deviceId) {

--- a/src/output.js
+++ b/src/output.js
@@ -1,3 +1,4 @@
+// @flow
 //const transforms = require('./glsl-transforms.js')
 
 var Output = function ({ regl, precision, label = "", width, height}) {

--- a/src/shader-generator.js
+++ b/src/shader-generator.js
@@ -1,3 +1,4 @@
+// @flow
 import Generator from './generator-factory.js'
 import Sandbox from './eval-sandbox.js'
 

--- a/src/shaderManager.js
+++ b/src/shaderManager.js
@@ -1,3 +1,4 @@
+// @flow
 // to do:
 // 1. how to handle multi-pass renders
 // 2. how to handle vertex shaders


### PR DESCRIPTION
atom-hydra package could not be updated to use the latest hydra-synth version, since the migration from CommonJS to ES module.
Atom/Pulsar packages are compiled with babel so that 'import's are converted to 'require's.
This in turns prevents using external ES modules, unless a special keyword in their source code triggers Pulsar to compile those external modules too.
This simple PR only adds this keyword to all files (I haven't found another solution).
See https://github.com/pulsar-edit/pulsar/blob/c16743e2c43a885c199077547635e59a56a8d7f5/src/babel.js#L11

We could use any of those keywords to make this patch work:
```
/** @babel */
"use babel"
'use babel'
/* @flow */
// @flow
```