### PR TITLE
Add workaround to error on Vite to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,15 @@ shape(4).diff(osc(2, 0.1, 1.2)).out()
 ### Known issues / troubleshooting
 
 #### Vite
-When using hydra with Vite, you might see the error 
+When using hydra with Vite, you might see the error `Uncaught ReferenceError: global is not defined`. This is an issue in `hydra-synth` dependency, which further depends on node's `global`. 
+
+- To fully mitigate the issue: add a polyfill for `global`. (See [ref](https://github.com/vitejs/vite/discussions/5912#discussioncomment-1724947))
+- To workaround: add the following snippet to `vite.config.json`. (See [ref](https://github.com/vitejs/vite/discussions/5912#discussioncomment-2908994))
+``` js
+define: {
+  global: {},
+},
+```
 
 #### Autoplay on iOS
 


### PR DESCRIPTION
In issue #145, we encountered an issue on Vite.

I found a [discussion](https://github.com/vitejs/vite/discussions/5912) on Vite's project and people provided valid mitigation & workaround. 

The workaround works on my PoC so I updated the `README.md` to shed some light on the late comer.

![image](https://github.com/hydra-synth/hydra-synth/assets/2971688/cdce950f-fea4-43ed-a0dc-27d8c83393af)


